### PR TITLE
docker-compose upで立ち上がるように設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 
 .DS_Store
 .idea
+permanent-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3"
+services:
+  web:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -b '0.0.0.0' -p 3000"
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+    tty: true
+    stdin_open: true
+    environment:
+      DB_USER: postgres
+      DB_PASS: dev
+      DB_PORT: 5432
+      DB_HOST: db
+      DB_NAME: dev
+      RAILS_ENV: development
+      TZ: Asia/Tokyo
+      HOST: localhost
+    depends_on:
+      - db
+
+  db:
+    image: "postgres:14"
+    command: postgres -c log_destination=stderr -c log_statement=all -c log_connections=on -c log_disconnections=on
+    volumes:
+      - .:/app
+      - ./initdb:/docker-entrypoint-initdb.d
+      - ./permanent-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: dev


### PR DESCRIPTION
## やったこと

今回の主な機能である、
```
8. Dockerで動かせる。
  - `docker compose up`で動くようにお願いします。
 ```
を実現すべく、`docker-compose.yml`を設定。

## ローカル確認用URL
http://localhost:3000/

## やったこと
- docker-compose.ymlを作成
- .gitignoreに`permanent-data`を追加

## このPRでやらなかったこと
この時点でDBはsqliteになっています。
railsを入れるとき、`rails new . -d postgresql`では
エラーが出てしまい、うまく起動しなかったためです。

<img width="716" alt="image" src="https://user-images.githubusercontent.com/67307579/210025342-b8b639bb-ce93-4d1a-a6d5-f7f819470e71.png">

dbを変えるためのPRは後ほど改めて出させていただきます。:bow:

## お気持ち
レビューよろしくお願い致します。:bow: